### PR TITLE
switched to setuptools so commands like develop are available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ A slightly more robust version of the native django redirect
 
 """
 import os
-from distutils.core import setup
+from setuptools import setup
 
 __version__ = "0.1"
 


### PR DESCRIPTION
I'd like to be able to work with the project in developer mode:

```
python setup.py develop
```

This change enables it. I don't know if change has any sideeffects.
